### PR TITLE
feat(code-coverage): Add workflow for tarpaulin over 90%

### DIFF
--- a/.github/workflows/code-coverage.yml
+++ b/.github/workflows/code-coverage.yml
@@ -1,0 +1,50 @@
+name: Code Coverage
+
+on:
+  pull_request:
+  # push:
+  #   branches:
+  #     - main
+    paths:
+      - '**/*.rs'
+      - '!LICENSE'
+      - '!README.md'
+      - '!**/*.md'
+
+jobs:
+  code-coverage:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Rust
+        run: |
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source $HOME/.cargo/env
+          rustup default stable
+
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+
+      - name: Install protoc (Protocol Buffers compiler)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler
+
+      - name: Run code coverage using external script
+          # Define repo level variable
+        env:
+          SKIP_CRATE: ${{ vars.SKIP_CRATE }}
+        run: |
+          chmod u+x scripts/run_coverage.sh
+          ./scripts/run_coverage.sh
+
+      - name: Upload coverage results
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: coverage-lcov
+          path: "**/coverage/lcov.info"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # bbpm
 Blockchain-based package manager, in Rust.
+
+```
+# for tarpaulin testing, to skip codo coverage for specific crate,
+# Request owner of repository to
+# navigate to the repository Settings-> Secrets and variables -> Actions -> Variables (Repository variables)
+# and update value for SKIP_CRATE variable.
+```

--- a/scripts/run_coverage.sh
+++ b/scripts/run_coverage.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Check if SKIP_CRATE is set
+if [ -z "$SKIP_CRATE" ]; then
+  echo "No crate to skip. Running tarpaulin for all crates."
+else
+  echo "Skipping crate: $SKIP_CRATE"
+fi
+
+# Find all crates by looking for Cargo.toml files
+for crate in $(find packages -name Cargo.toml -exec dirname {} \;); do
+  CRATE_NAME=$(basename $crate)
+
+  # Skip the crate if SKIP_CRATE is set and matches the current crate
+  if [ -n "$SKIP_CRATE" ] && [ "$CRATE_NAME" = "$SKIP_CRATE" ]; then
+    echo "Skipping tarpaulin for $CRATE_NAME"
+    continue
+  fi
+
+  echo "Running coverage for crate: $CRATE_NAME"
+  mkdir -p "$crate/tarpaulin_temp"
+  mkdir -p "$crate/coverage"
+  
+  cargo tarpaulin --manifest-path $crate/Cargo.toml --out lcov \
+    --output-dir $crate/coverage --exclude-files "/target/**/*" "/tarpaulin_temp/**/*" \
+    --target-dir $crate/tarpaulin_temp --skip-clean || echo "Tarpaulin failed for $CRATE_NAME"
+done


### PR DESCRIPTION
I tested by adding an empty line to packages/core/mod.rs which triggered the github actions workflow with tarpaulin.
result: https://github.com/Meta-A/bbpm/actions/runs/11450615177/job/31858393768
And if I modify or add files which are not relevant to crates - then tarpaulin is not running ^^